### PR TITLE
方法名冲突

### DIFF
--- a/src/aspect_behavior.js
+++ b/src/aspect_behavior.js
@@ -8,7 +8,7 @@
         * @param {String} methodName 被插队的方法名
         * @param {Function} callback 插入的方法
         * */
-        before: function before(methodName, callback) {
+        _before: function before(methodName, callback) {
             weaver.call(this, 'before', methodName, callback);
             return this;
         },
@@ -18,7 +18,7 @@
         * @param {String} methodName 被插队的方法名
         * @param {Function} callback 插入的方法
         * */
-        after: function after(methodName, callback) {
+        _after: function after(methodName, callback) {
             weaver.call(this, 'after', methodName, callback);
             return this;
         }


### PR DESCRIPTION
IOS10实现了HTMLElement的before与after函数，导致 IOS10 浏览器中出现显示代码的问题，需要修改下函数名
